### PR TITLE
Updating version constraints for Laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       env: ILLUMINATE_VERSION=5.6.*
     - php: 7.1
       env: ILLUMINATE_VERSION=5.7.*
+    - php: 7.1
+      env: ILLUMINATE_VERSION=5.8.*
     - php: 7.2
       env: ILLUMINATE_VERSION=5.4.*
     - php: 7.2
@@ -28,6 +30,8 @@ matrix:
       env: ILLUMINATE_VERSION=5.6.*
     - php: 7.2
       env: ILLUMINATE_VERSION=5.7.*
+    - php: 7.2
+      env: ILLUMINATE_VERSION=5.8.*
 
 before_install: travis_retry composer require "illuminate/database:${ILLUMINATE_VERSION}" "illuminate/events:${ILLUMINATE_VERSION}" --no-update -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,16 @@ matrix:
       env: ILLUMINATE_VERSION=5.7.*
     - php: 7.2
       env: ILLUMINATE_VERSION=5.8.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.4.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.5.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.6.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.7.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.8.*
 
 before_install: travis_retry composer require "illuminate/database:${ILLUMINATE_VERSION}" "illuminate/events:${ILLUMINATE_VERSION}" --no-update -v
 

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "type": "utility",
   "require": {
     "php": ">=5.6.4 || >= 7.0 || ^7.1.3",
-    "illuminate/container": "5.4.* || 5.5.* || 5.6.* || 5.7.*",
-    "illuminate/database": "5.4.* || 5.5.* || 5.6.* || 5.7.*"
+    "illuminate/container": "5.4 - 5.8",
+    "illuminate/database": "5.4 - 5.8"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
   "description": "A package to override Laravel migrations to more efficiently store UUID fields in your database",
   "type": "utility",
   "require": {
-    "php": ">=5.6.4 || >= 7.0 || ^7.1.3",
-    "illuminate/container": "5.4 - 5.8",
-    "illuminate/database": "5.4 - 5.8"
+    "php": ">=5.6.4",
+    "illuminate/container": "~5.4",
+    "illuminate/database": "~5.4"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Laravel 5.8 has been released; and this Pull-Request updates the version requirements to allow the installation alongside the new version.

I have also cleaned up the constraints a little by using the range constraint in composer.