### PR TITLE
Move orchestra/testbench to dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
   "require": {
     "php": "^7.2",
     "illuminate/container": "^6.0",
-    "illuminate/database": "^6.0",
-    "orchestra/testbench": "^4.0"
+    "illuminate/database": "^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
-    "mockery/mockery": "^1.2.3"
+    "mockery/mockery": "^1.2.3",
+    "orchestra/testbench": "^4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Is there a reason orchestra/testbench is a production dependency?