### PR TITLE
Add support for modifying existing efficientUuid columns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": "^7.2",
     "illuminate/container": "^6.0",
-    "illuminate/database": "^6.0"
+    "illuminate/database": "^6.0",
+    "doctrine/dbal": "^2.10"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/src/LaravelEfficientUuidServiceProvider.php
+++ b/src/LaravelEfficientUuidServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace Dyrynda\Database;
 
+use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\Types\BinaryType;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
 use Dyrynda\Database\Connection\MySqlConnection;
@@ -17,7 +20,11 @@ class LaravelEfficientUuidServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::registerCustomDoctrineType(
+            BinaryType::class,
+            'efficientuuid',
+            Types::BINARY
+        );
     }
 
     /**

--- a/tests/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/DatabaseMySqlSchemaGrammarTest.php
@@ -3,8 +3,11 @@
 namespace Tests;
 
 use Mockery as m;
+use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Capsule\Manager as DB;
 use Dyrynda\Database\Schema\Grammars\MySqlGrammar;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
@@ -27,5 +30,27 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
             ['alter table `users` add `foo` char(36) not null, add `bar` binary(16) not null'],
             $blueprint->toSql($connection, new MySqlGrammar)
         );
+    }
+
+    public function testChangingUuid()
+    {
+        app('db')->connection()->getSchemaBuilder()->create('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuid('bar');
+        });
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->efficientUuid('bar')->nullable(false)->change();
+        });
+
+        $expected = [
+            'CREATE TEMPORARY TABLE __temp__users AS SELECT foo, bar FROM users',
+            'DROP TABLE users',
+            'CREATE TABLE users (foo VARCHAR(255) NOT NULL COLLATE BINARY, bar BLOB NOT NULL)',
+            'INSERT INTO users (foo, bar) SELECT foo, bar FROM __temp__users',
+            'DROP TABLE __temp__users',
+        ];
+
+        $this->assertEquals($expected, $blueprint->toSql(app('db')->connection(), new MySqlGrammar));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,4 +12,13 @@ class TestCase extends \Orchestra\Testbench\TestCase
             LaravelEfficientUuidServiceProvider::class,
         ];
     }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+    }
 }


### PR DESCRIPTION
I wasn't sure specifically how to test this, and borrowed some of the behaviour from the [framework's tests](https://github.com/laravel/framework/blob/6.x/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php#L46), to verify the behaviour.