### PR TITLE
Cast value as string when using trim

### DIFF
--- a/src/Casts/EfficientUuid.php
+++ b/src/Casts/EfficientUuid.php
@@ -18,7 +18,7 @@ class EfficientUuid implements CastsAttributes
      */
     public function get($model, string $key, $value, array $attributes)
     {
-        if (trim($value) === '') {
+        if (trim((string) $value) === '') {
             return;
         }
 
@@ -36,7 +36,7 @@ class EfficientUuid implements CastsAttributes
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        if (trim($value) === '') {
+        if (trim((string) $value) === '') {
             return;
         }
 


### PR DESCRIPTION
This fixes the deprecation warning in PHP 8.1.

```trim(): Passing null to parameter #1 ($string) of type string is deprecated in ...```