### PR TITLE
Adds a new macro to mirror Laravel's foreignIdFor builder

### DIFF
--- a/src/LaravelEfficientUuidServiceProvider.php
+++ b/src/LaravelEfficientUuidServiceProvider.php
@@ -33,5 +33,21 @@ class LaravelEfficientUuidServiceProvider extends ServiceProvider
             /** @var \Illuminate\Database\Schema\Blueprint $this */
             return $this->addColumn('efficientUuid', $column);
         });
+
+        Blueprint::macro(
+            'efficientUuidFor',
+            /**
+             * @param  \Illuminate\Database\Eloquent\Model|string  $model
+             * @param string|null $column
+             * @return ColumnDefinition
+             */
+            function ($model, ?string $column = null): ColumnDefinition {
+                if (is_string($model)) {
+                    $model = new $model;
+                }
+                /** @var \Illuminate\Database\Schema\Blueprint $this */
+                return $this->addColumn('efficientUuid', $column ?: $model->getForeignKey());
+            }
+        );
     }
 }

--- a/tests/DatabaseInvalidSchemaGrammarTest.php
+++ b/tests/DatabaseInvalidSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 use Mockery as m;
+use Tests\Fixtures\EfficientUuidPost;
 
 class DatabaseInvalidSchemaGrammarTest extends TestCase
 {
@@ -20,6 +21,20 @@ class DatabaseInvalidSchemaGrammarTest extends TestCase
         $blueprint = new Blueprint('users', function ($table) {
             $table->uuid('foo');
             $table->efficientUuid('bar');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->expectExceptionObject(new UnknownGrammarClass());
+
+        $blueprint->toSql($connection, new SqlServerGrammar);
+    }
+
+    public function testAddingUuidFor()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class);
         });
 
         $connection = m::mock(Connection::class);

--- a/tests/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/DatabaseMySqlSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Mockery as m;
+use Tests\Fixtures\EfficientUuidPost;
 
 class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
@@ -19,6 +20,36 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint = new Blueprint('users', function ($table) {
             $table->uuid('foo');
             $table->efficientUuid('bar');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(
+            ['alter table `users` add `foo` char(36) not null, add `bar` binary(16) not null'],
+            $blueprint->toSql($connection, new MySqlGrammar)
+        );
+    }
+
+    public function testAddingUuidFor()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class);
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(
+            ['alter table `users` add `foo` char(36) not null, add `efficient_uuid_post_id` binary(16) not null'],
+            $blueprint->toSql($connection, new MySqlGrammar)
+        );
+    }
+
+    public function testAddingUuidForWithCustomColumn()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class, 'bar');
         });
 
         $connection = m::mock(Connection::class);

--- a/tests/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/DatabasePostgresSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Mockery as m;
+use Tests\Fixtures\EfficientUuidPost;
 
 class DatabasePostgresSchemaGrammarTest extends TestCase
 {
@@ -19,6 +20,36 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint = new Blueprint('users', function ($table) {
             $table->uuid('foo');
             $table->efficientUuid('bar');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(
+            ['alter table "users" add column "foo" uuid not null, add column "bar" bytea not null'],
+            $blueprint->toSql($connection, new PostgresGrammar)
+        );
+    }
+
+    public function testAddingUuidFor()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class);
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(
+            ['alter table "users" add column "foo" uuid not null, add column "efficient_uuid_post_id" bytea not null'],
+            $blueprint->toSql($connection, new PostgresGrammar)
+        );
+    }
+
+    public function testAddingUuidForWithCustomColumn()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class, 'bar');
         });
 
         $connection = m::mock(Connection::class);

--- a/tests/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/DatabaseSQLiteSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Mockery as m;
+use Tests\Fixtures\EfficientUuidPost;
 
 class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
@@ -19,6 +20,36 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint = new Blueprint('users', function ($table) {
             $table->uuid('foo');
             $table->efficientUuid('bar');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(
+            ['alter table "users" add column "foo" varchar not null', 'alter table "users" add column "bar" blob(256) not null'],
+            $blueprint->toSql($connection, new SQLiteGrammar)
+        );
+    }
+
+    public function testAddingUuidFor()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class);
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(
+            ['alter table "users" add column "foo" varchar not null', 'alter table "users" add column "efficient_uuid_post_id" blob(256) not null'],
+            $blueprint->toSql($connection, new SQLiteGrammar)
+        );
+    }
+
+    public function testAddingUuidForWithCustomColumn()
+    {
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->uuid('foo');
+            $table->efficientUuidFor(EfficientUuidPost::class, 'bar');
         });
 
         $connection = m::mock(Connection::class);


### PR DESCRIPTION
I use the `->foreignIdFor(ExampleModel::class)` a lot, and was hoping to add this macro as a way to allow this as part of this package. If you are not accepting additional features, feel free to close this.